### PR TITLE
Prepare packages before tagging of 2.0.1 release

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Nginx, Inc.
+ * Copyright (C) 2011-2019 Nginx, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ software components installed:
 You can build this tool for rpm or debian using the Makefile. Output will be in the `build_output/` directory.
 
 
-```
+```console
 $ make rpm
 ```
 
-```
+```console
 $ make debian
 ```
 
@@ -154,7 +154,7 @@ export HTTPS_PROXY="your-proxy-host.example.com:3128"
 Plugin can be started as a daemon (default) or in foreground mode.
 In order to start it daemonized, use the following command under root:
 
-```
+```console
 $ service nginx-nr-agent start
 ```
 
@@ -163,20 +163,20 @@ into /var/log/nginx-nr-agent.log.
 
 Plugin status can be checked by running:
 
-```
+```console
 $ service nginx-nr-agent status
 ```
 
 To stop plugin, use:
 
-```
+```console
 $ service nginx-nr-agent stop
 ```
 
 For debugging purposes, you can launch the plugin in foreground mode,
 with all output going to stdout:
 
-```
+```console
 $ nginx-nr-agent.py -f start
 ```
 

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,6 +1,6 @@
 /* 
- * Copyright (C) 2002-2018 Igor Sysoev
- * Copyright (C) 2011-2018 Nginx, Inc.
+ * Copyright (C) 2002-2019 Igor Sysoev
+ * Copyright (C) 2011-2019 Nginx, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/nginx-nr-agent.py
+++ b/nginx-nr-agent.py
@@ -15,7 +15,7 @@ import traceback
 
 NEWRELIC_API_URL = 'https://platform-api.newrelic.com/platform/v1/metrics'
 AGENT_GUID = 'com.nginx.newrelic-agent'
-AGENT_VERSION = '2.0.0'
+AGENT_VERSION = '2.0.1'
 API_VERSION = '1'
 
 DEFAULT_CONFIG_FILE = '/etc/nginx-nr-agent/nginx-nr-agent.ini'

--- a/rpm/SOURCES/COPYRIGHT
+++ b/rpm/SOURCES/COPYRIGHT
@@ -1,6 +1,6 @@
 /* 
- * Copyright (C) 2002-2018 Igor Sysoev
- * Copyright (C) 2011-2018 Nginx, Inc.
+ * Copyright (C) 2002-2019 Igor Sysoev
+ * Copyright (C) 2011-2019 Nginx, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Prepare packages before tagging latest commit as 2.0.1 as requested: https://github.com/nginxinc/new-relic-agent/issues/7

* Update agent version 
* Update copyright year
* Fix syntax highlighting in README